### PR TITLE
New triples

### DIFF
--- a/src/omero_rdf/__init__.py
+++ b/src/omero_rdf/__init__.py
@@ -31,6 +31,7 @@ from omero.model import Dataset, Image, IObject, Plate, Project, Screen
 from omero.sys import ParametersI
 from omero_marshal import get_encoder
 from rdflib import BNode, Literal, URIRef
+from rdflib.namespace import RDF
 
 HELP = """A plugin for exporting rdf from OMERO
 
@@ -196,8 +197,10 @@ class Handler:
 
         for k, v in sorted(data.items()):
 
-            if k in ("@type", "@id", "omero:details", "Annotations"):
-                # Types that we want to omit fo
+            if k == "@type":
+                yield (_id, RDF.type, URIRef(v))
+            elif k in ("@id", "omero:details", "Annotations"):
+                # Types that we want to omit for now
                 pass
             else:
 

--- a/src/omero_rdf/__init__.py
+++ b/src/omero_rdf/__init__.py
@@ -385,7 +385,7 @@ class RdfControl(BaseControl):
             scrid = handler(scr)
             for plate in scr.listChildren():
                 pltid = self.descend(gateway, plate._obj, handler)
-                handler.emit((scrid, DCTERMS.isPartOf, pltid))
+                handler.emit((pltid, DCTERMS.isPartOf, scrid))
             for annotation in scr.listAnnotations(None):
                 handler(annotation)
             return scrid
@@ -397,12 +397,12 @@ class RdfControl(BaseControl):
                 handler(annotation)
             for well in plt.listChildren():
                 wid = handler(well)  # No descend
-                handler.emit((pltid, DCTERMS.isPartOf, wid))
+                handler.emit((wid, DCTERMS.isPartOf, pltid))
                 for idx in range(0, well.countWellSample()):
                     img = well.getImage(idx)
                     imgid = handler(img.getPrimaryPixels())
                     handler(img)  # No descend
-                    handler.emit((wid, DCTERMS.isPartOf, imgid))
+                    handler.emit((imgid, DCTERMS.isPartOf, wid))
             return pltid
 
         elif isinstance(target, Project):
@@ -412,7 +412,7 @@ class RdfControl(BaseControl):
                 handler(annotation)
             for ds in prj.listChildren():
                 dsid = self.descend(gateway, ds._obj, handler)
-                handler.emit((prjid, DCTERMS.isPartOf, dsid))
+                handler.emit((dsid, DCTERMS.isPartOf, prjid))
             return prjid
 
         elif isinstance(target, Dataset):
@@ -422,7 +422,7 @@ class RdfControl(BaseControl):
                 handler(annotation)
             for img in ds.listChildren():
                 imgid = handler(img)  # No descend
-                handler.emit((dsid, DCTERMS.isPartOf, imgid))
+                handler.emit((imgid, DCTERMS.isPartOf, dsid))
                 handler(img.getPrimaryPixels())
                 for annotation in img.listAnnotations(None):
                     handler(annotation)

--- a/src/omero_rdf/__init__.py
+++ b/src/omero_rdf/__init__.py
@@ -132,11 +132,16 @@ class Handler:
     def get_type(self, data: Data) -> str:
         return data.get("@type", "UNKNOWN").split("#")[-1]
 
-    def ellide(self, v: Any) -> Literal:
+    def literal(self, v: Any) -> Literal:
+        """
+        Prepare Python objects for use as literals
+        """
         if isinstance(v, str):
             v = str(v)
             if self.use_ellide and len(v) > 50:
                 v = f"{v[0:24]}...{v[-20:-1]}"
+            elif v.startswith(" ") or v.endswith(" "):
+                logging.warning("string has whitespace that needs trimming: '%s'", v)
         return Literal(v)
 
     def get_class(self, o):
@@ -247,17 +252,17 @@ class Handler:
                             yield (
                                 bnode,
                                 URIRef(f"{self.OME}Key"),
-                                self.ellide(item[0]),
+                                self.literal(item[0]),
                             )
                             yield (
                                 bnode,
                                 URIRef(f"{self.OME}Value"),
-                                self.ellide(item[1]),
+                                self.literal(item[1]),
                             )
                         else:
                             raise Exception(f"unknown list item: {item}")
                 else:
-                    yield (_id, key, self.ellide(v))  # TODO: Use Literal
+                    yield (_id, key, self.literal(v))
 
         # Special handling for Annotations
         annotations = data.get("Annotations", [])

--- a/src/omero_rdf/__init__.py
+++ b/src/omero_rdf/__init__.py
@@ -88,10 +88,11 @@ class Handler:
     OME = "http://www.openmicroscopy.org/rdf/2016-06/ome_core/"
     OMERO = "http://www.openmicroscopy.org/TBD/omero/"
 
-    def __init__(self, gateway: BlitzGateway) -> None:
+    def __init__(self, gateway: BlitzGateway, use_ellide=False) -> None:
         self.gateway = gateway
         self.cache: Set[URIRef] = set()
         self.bnode = 0
+        self.use_ellide = False
         self.annotation_handlers: List[
             Callable[[URIRef, URIRef, Data], Generator[Triple, None, bool]]
         ] = []
@@ -133,7 +134,7 @@ class Handler:
     def ellide(self, v: Any) -> Literal:
         if isinstance(v, str):
             v = str(v)
-            if len(v) > 50:
+            if self.use_ellide and len(v) > 50:
                 v = f"{v[0:24]}...{v[-20:-1]}"
         return Literal(v)
 

--- a/src/omero_rdf/__init__.py
+++ b/src/omero_rdf/__init__.py
@@ -316,7 +316,7 @@ class Handler:
                     break
 
             if not handled:  # TODO: could move to a default handler
-                aid = (self.get_identity("AnnotationTBD", annotation["@id"]),)
+                aid = self.get_identity("AnnotationTBD", annotation["@id"])
                 yield (_id, URIRef(f"{self.OME}annotation"), aid)
                 yield from self.rdf(aid, annotation)
 

--- a/src/omero_rdf/__init__.py
+++ b/src/omero_rdf/__init__.py
@@ -370,8 +370,7 @@ class RdfControl(BaseControl):
                     join fetch s.annotationLinks as sal
                     join fetch sal.child as sann"""
             for roi in gateway.getQueryService().findAllByQuery(
-                query,
-                params,
+                query, params, {"omero.group": str(img.details.group.id.val)}
             ):
                 handler(roi)
 


### PR DESCRIPTION
This PR works to better connect and complete the graph returned from `omero rdf`. New triples include:

* [x] RDFs and Shapes and their Annotations
* [x] `rdf:type` for all major OMERO types
* [x] `dcterms:isPartOf` for the links between major OMERO types
* [ ] ~~Include DCAT triples with the top-level objects and the host info~~

Propose release as 0.3.0 but further proposals for additional triples welcome.

cc: @CFGrote @andrawaag @sukunis 

* [x] Note: Full support of all the triples a new release of omero-marshal with https://github.com/ome/omero-marshal/pull/78 is needed.