### PR TITLE
Add missing setuptools_scm section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ requires = [
     "setuptools-scm>=8.0",
 ]
 
+[tool.setuptools_scm]
+
 [tools.setuptools.dynamic]
 version = {attr = "omero_rdf.__version__"}
 


### PR DESCRIPTION
Running `python -m setuptools_scm` on main:

```
Warning: could not use pyproject.toml, using default configuration.
 Reason: /opt/omero-rdf/pyproject.toml does not contain a tool.setuptools_scm section.
/Users/jamoore/micromamba/envs/omero-rdf/lib/python3.10/site-packages/setuptools_scm/_config.py:71: UserWarning: relative_to is expected to be a file, its the directory .
assuming the parent directory was passed
  warnings.warn(
0.3.0
```
With this change:
```
0.3.1.dev0+g22e9651.d20240318
```

Propose releasing as 0.3.1 ASAP.