### PR TITLE
Add "packaging" module to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "rdflib",
     "omero-marshal",
     "wikidataintegrator",
+    "packaging"
 ]
 
 classifiers = [


### PR DESCRIPTION
Error I got after freshly installing from `pip`:

![image](https://github.com/German-BioImaging/omero-rdf/assets/17748742/2f3fd66e-2fa9-41f3-958c-ca18cace0ae5)
