### PR TITLE
Escape n3 triples to deal with multiline issues

### DIFF
--- a/src/omero_rdf/__init__.py
+++ b/src/omero_rdf/__init__.py
@@ -223,7 +223,8 @@ class Handler:
         else:
             # Streaming
             s, p, o = triple
-            print(f"""{s.n3()}\t{p.n3()}\t{o.n3()} .""")
+            escaped = o.n3().encode("unicode_escape").decode("utf-8")
+            print(f"""{s.n3()}\t{p.n3()}\t{escaped} .""")
 
     def close(self):
         if self.pretty_print:
@@ -376,7 +377,7 @@ class RdfControl(BaseControl):
         """
 
         if isinstance(target, list):
-            return([self.descend(gateway, t, handler) for t in target])
+            return [self.descend(gateway, t, handler) for t in target]
 
         elif isinstance(target, Screen):
             scr = self._lookup(gateway, "Screen", target.id)


### PR DESCRIPTION
@andrawaag has been running into issues with various parsers due to the newlines in literals:

```
http://www.openmicroscopy.org/rdf/2016-06/ome_core/Value      """<SegmentDefinition>
          <Name>example</Name>
          ...
        </SegmentDefinition>""" .
```

Based on:
* https://stackoverflow.com/questions/15392730/in-python-is-it-possible-to-escape-newline-characters-when-printing-a-string
* https://stackoverflow.com/questions/74643162/python-rdflib-string-to-uriref-or-literal-inverse-of-n3-method
produces strings with embedded `\n` escapes:

```
<http://www.openmicroscopy.org/rdf/2016-06/ome_core/Value>      """<ChannelThresholds>\n          <RoiName>012</RoiName>\n 
```

If this is not sufficient, then we may need to create a `Graph` object *very* frequently and use the `.serialize()` method.