### PR TITLE
Update dependencies in .isort.cfg

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = entrypoints,omero,omero_marshal,omero_rdf,pyld,rdflib,rdflib_pyld_compat,wikidataintegrator
+known_third_party = omero,omero_marshal,omero_rdf,pyld,rdflib,rdflib_pyld_compat


### PR DESCRIPTION
Left out importlib_metadata, which is part of the Python standard library.