### PR TITLE
Fix pypi push

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -10,13 +10,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Build a binary wheel and a source tarball
         run: |
-          python -mpip install setuptools build wheel
+          python -m pip install setuptools build wheel
           python -m build
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.8.14
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-            fetch-depth: 0
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'


### PR DESCRIPTION

https://github.com/German-BioImaging/omero-rdf/actions/runs/22221963829 failed with one warning and one error: 


*Warning*: Trusted Publishers allows publishing packages to PyPI from automated environments like GitHub Actions without needing to use username/password combinations or API tokens to authenticate with PyPI. Read more: https://docs.pypi.org/trusted-publishers


**ERROR**: Checking dist/omero_rdf-0.7.0-py3-none-any.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name, Version.  Make sure the distribution includes the files where those fields are specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 2.3.                                                    

The culprit may be the checkout workflow, which fetches with no tags:

```
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +261c70948226f10ebad209f223bf1adb1438a222:refs/tags/v0.7.0
```

Via https://github.com/actions/checkout, "Set fetch-depth: 0 to fetch all history for all branches and tags."