### PR TITLE
fix: Comment out zeroc-ice Python wheels

### DIFF
--- a/.github/workflows/omero_plugin.yml
+++ b/.github/workflows/omero_plugin.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - run: pip install -r zeroc-ice-requirements.txt
       - run: pip install ".[tests]"
       - name: Test package
         run: >-
@@ -57,6 +58,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - run: pip install -r zeroc-ice-requirements.txt
       - run: pip install ".[tests]"
       - run: pytest test/integration/test_idr
 
@@ -74,6 +76,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - run: pip install -r zeroc-ice-requirements.txt
       - run: pip install pre-commit
       - run: pre-commit run --all-files
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Requirements
 Installing from PyPI
 ====================
 
-This section assumes that an `OMERO.py <https://github.com/ome/omero-py>`_ is already installed.
+This section assumes that an `OMERO.py <https://github.com/ome/omero-py>`_ is already installed and zeroc-ice is configured.
 
 Install the command-line tool using `pip <https://pip.pypa.io/en/stable/>`_:
 
@@ -29,7 +29,7 @@ Install the command-line tool using `pip <https://pip.pypa.io/en/stable/>`_:
     $ pip install -U omero-rdf
 
 
-Developer guidelines 
+Developer guidelines
 ====================
 
 Using `uv` (recommended):
@@ -44,30 +44,32 @@ Using `uv` (recommended):
 
    (or prefix commands with ``uv run`` instead of activating).
 
-3. Install in editable mode with test dependencies (pulls the correct platform-specific ``zeroc-ice`` wheel):
+3. Uncomment the lines on `pyproject.toml` related to `zeroc-ice` installation.
+
+4. Install in editable mode with test dependencies:
 
    ::
 
        uv pip install -e ".[tests,dev]"
 
-4. Run the test suite:
+5. Run the test suite:
 
    ::
 
-       pytest test/unit 
+       pytest test/unit
        pytest test/integration/test_idr
 
-5. Lint and format:
+6. Lint and format:
 
    ::
 
-       ruff check 
+       ruff check
        ruff format --check
        ruff format
- 
+
 To run pre-commit hooks:
 
-:: 
+::
 
    uv tool install pre-commit
    pre-commit run --all-files
@@ -76,19 +78,19 @@ Quick check against IDR
 -----------------------
 
 Assuming you have the `uv` environment active (`source .venv/bin/activate`), use
-the public IDR server to confirm the CLI works (public/public credentials):
+the public IDR server to confirm the CLI works (public credentials):
 
 1. Log in once to create a session:
 
    ::
 
-       omero login -s idr.openmicroscopy.org -u public -w public
+       omero login -s idr.openmicroscopy.org -u [PUBLIC USER] -w [PUBLIC PASSWORD]
 
 2. Export RDF for a project on IDR (2902) and inspect the first triples:
 
    ::
 
-       omero rdf -F=turtle Project:2902 -S=flat | head  -n 10       
+       omero rdf -F=turtle Project:2902 -S=flat | head  -n 10
 
 Release process
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -44,22 +44,20 @@ Using `uv` (recommended):
 
    (or prefix commands with ``uv run`` instead of activating).
 
-3. Uncomment the lines on `pyproject.toml` related to `zeroc-ice` installation.
-
-4. Install in editable mode with test dependencies:
+3. Install in editable mode with test dependencies:
 
    ::
-
+       uv pip install -r zeroc-ice-requirements.txt
        uv pip install -e ".[tests,dev]"
 
-5. Run the test suite:
+4. Run the test suite:
 
    ::
 
        pytest test/unit
        pytest test/integration/test_idr
 
-6. Lint and format:
+5. Lint and format:
 
    ::
 
@@ -73,6 +71,7 @@ To run pre-commit hooks:
 
    uv tool install pre-commit
    pre-commit run --all-files
+
 
 Quick check against IDR
 -----------------------
@@ -91,6 +90,14 @@ the public IDR server to confirm the CLI works (public credentials):
    ::
 
        omero rdf -F=turtle Project:2902 -S=flat | head  -n 10
+
+Mocking GitHub Actions checks
+
+1. If you have gh installed, you can run the checks locally:
+
+   ::
+
+       gh act push
 
 Release process
 ---------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,15 @@ dependencies = [
     "rdflib-pyld-compat",
     "omero-marshal",
     "packaging",
-    'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.10"',
-    'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.11"',
-    'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.12"',
-    'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp310-cp310-macosx_11_0_universal2.whl ; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.10"',
-    'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp311-cp311-macosx_11_0_universal2.whl ; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.11"',
-    'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp312-cp312-macosx_11_0_universal2.whl ; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.12"'
+    #  zeroc-ice is a dependency of omero-py that needs to be installed in advance. See https://omero.readthedocs.io/en/stable/developers/Python.html for details. 
+    #  The following lines are a shortcut to install the appropriate wheels provided by glencoesoftware.
+    #  They are commented out as they are not accepted by the PyPI validator, but can be uncommented for local development and testing.
+    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.10"',
+    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.11"',
+    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.12"',
+    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp310-cp310-macosx_11_0_universal2.whl ; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.10"',
+    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp311-cp311-macosx_11_0_universal2.whl ; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.11"',
+    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp312-cp312-macosx_11_0_universal2.whl ; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.12"'
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,15 +26,8 @@ dependencies = [
     "rdflib-pyld-compat",
     "omero-marshal",
     "packaging",
-    #  zeroc-ice is a dependency of omero-py that needs to be installed in advance. See https://omero.readthedocs.io/en/stable/developers/Python.html for details. 
-    #  The following lines are a shortcut to install the appropriate wheels provided by glencoesoftware.
-    #  They are commented out as they are not accepted by the PyPI validator, but can be uncommented for local development and testing.
-    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.10"',
-    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.11"',
-    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.12"',
-    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp310-cp310-macosx_11_0_universal2.whl ; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.10"',
-    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp311-cp311-macosx_11_0_universal2.whl ; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.11"',
-    # 'zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp312-cp312-macosx_11_0_universal2.whl ; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.12"'
+    #  zeroc-ice is a dependency of omero-py that needs to be installed in advance. 
+    # See https://omero.readthedocs.io/en/stable/developers/Python.html for details.
 ]
 
 classifiers = [

--- a/zeroc-ice-requirements.txt
+++ b/zeroc-ice-requirements.txt
@@ -1,0 +1,6 @@
+zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.10"
+zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.11"
+zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl ; platform_system=="Linux" and python_version=="3.12"
+zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp310-cp310-macosx_11_0_universal2.whl ; platform_system=="Darwin" and python_version=="3.10"
+zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp311-cp311-macosx_11_0_universal2.whl ; platform_system=="Darwin" and python_version=="3.11"
+zeroc-ice @ https://github.com/glencoesoftware/zeroc-ice-py-macos-universal2/releases/download/20240131/zeroc_ice-3.6.5-cp312-cp312-macosx_11_0_universal2.whl ; platform_system=="Darwin" and python_version=="3.12"


### PR DESCRIPTION
While adding the Glencoe zeroc-ice wheels made it really straightforward to install locally, it made `omero-rdf` incompatible with PyPI. 

I have removed that from `pyproject.toml` and added supporting documentation. 

I tested localy with test.pypi.org: 
 
```
git tag v0.7.2 
git checkout refs/tags/v0.7.2
python3 -m build
twine upload --repository testpypi dist/* --verbose
```

and it worked: https://test.pypi.org/project/omero-rdf/ 

this should close #69, but perhaps not. I have noticed that versions `0.6.2` and `0.6.3` have [similarly failed](https://github.com/German-BioImaging/omero-rdf/actions/workflows/publish_pypi.yml), but logs are too old to check. 
