### PR TITLE
Trusted Publishing on PyPI (Pilot) 

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Debug tags on HEAD
+        run: |
+          git rev-parse HEAD
+          git tag --points-at HEAD
+          git describe --tags --always
+          echo "GITHUB_REF=$GITHUB_REF"
+          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
+    
       - name: Build sdist and wheel
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,8 +1,6 @@
 name: TestPyPI
 
-on:
-  release:
-    types: [published]
+on: push
 
 permissions:
   contents: read
@@ -37,6 +35,7 @@ jobs:
   publish:
     name: Publish to TestPyPI
     needs: build
+    if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           ref: ${{ github.ref }}     # refs/tags/<tag> for releases
           fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,24 +1,53 @@
----
-name: PyPI
-on: push
+name: TestPyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
 
 jobs:
-  build-n-publish:
-    name: Build and publish Python distribution to PyPI
+  build:
+    name: Build distributions (from release tag)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }}     # refs/tags/<tag> for releases
           fetch-depth: 0
+
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      - name: Build a binary wheel and a source tarball
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
         run: |
-          python -m pip install setuptools build wheel
+          python -m pip install --upgrade pip
+          python -m pip install build
           python -m build
-      - name: Publish distribution to PyPI
-        if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
         with:
-          password: ${{ secrets.PYPI_PASSWORD }}
+          name: dist
+          path: dist/*
+
+  publish:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.13.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/


### PR DESCRIPTION
As a record: 

> [!NOTE]
> only the changes on [.github/workflows/publish_pypi.yml](https://github.com/German-BioImaging/omero-rdf/compare/main...lubianat:omero-rdf:trusted-publishing?expand=1#diff-22966fe1865c208453d2318c03d1247f3106dad4d5e5ea4dbb3e2ebcf1d0065b) are relevant

This builds upon https://github.com/German-BioImaging/omero-rdf/issues/69 to test the PyPI Trusted Publishing workflow, related to:

- #67 

Here is the deploy on test.pypi: https://test.pypi.org/project/omero-rdf 

I have: 

* Set up trusted publishing connecting my personal `lubianat/omero-rdf` branch to my Test PyPI `omero-rdf` project infrastructure (there)
* Updated the publishing workflow to not use a SECRET, but to mint tokens on every run
* Split build from publishing steps (as they require different permissions) 

Some notes: 

* Pushing a tag after another (i.e. without a new commit) does not work, as the inner mechanism of the GitHub checkout action will pick the first tag linked to a certain commit

In other words: releases without intermediary commits won't work with this publishing workflow

* Tags on my repo [do not propagate to pull requests](https://stackoverflow.com/questions/12278660/adding-tags-to-a-pull-request), so the releases there have no effect here

> [!WARNING]
> For this workflow to work on this repository, a maintainer of `omero-rdf` on PyPI needs to configure Trusted Publishing there. It entails basically filling a form with 5 quick entries. 